### PR TITLE
Fixed bots going through barricades

### DIFF
--- a/lua/d3bot/sv_zs_bot_handler/handlers/undead_fallback.lua
+++ b/lua/d3bot/sv_zs_bot_handler/handlers/undead_fallback.lua
@@ -79,6 +79,16 @@ function HANDLER.ThinkFunction(bot)
 	
 	local botPos = bot:GetPos()
 	
+	local tracedata = {start=nil,endpos=nil,mask=MASK_PLAYERSOLID,filter=nil}
+	tracedata.start = bot:GetPos()
+	tracedata.endpos = tracedata.start
+	tracedata.filter = bot
+	local traceResult = util.TraceEntity(tracedata,bot)
+	
+	if bot:Alive() and traceResult.StartSolid == true and (traceResult.Entity and not traceResult.Entity:IsWorld()) and (traceResult.Entity and (not traceResult.Entity.IsPlayer or not traceResult.Entity:IsPlayer()) ) then -- is stuck
+		bot:Kill()
+	end
+	
 	if mem.nextUpdateSurroundingPlayers and mem.nextUpdateSurroundingPlayers < CurTime() or not mem.nextUpdateSurroundingPlayers then
 		if not mem.TgtOrNil or IsValid(mem.TgtOrNil) and mem.TgtOrNil:GetPos():Distance(botPos) > HANDLER.BotTgtFixationDistMin then
 			mem.nextUpdateSurroundingPlayers = CurTime() + 1

--- a/lua/d3bot/sv_zs_bot_handler/handlers/undead_fallback.lua
+++ b/lua/d3bot/sv_zs_bot_handler/handlers/undead_fallback.lua
@@ -85,7 +85,7 @@ function HANDLER.ThinkFunction(bot)
 	tracedata.filter = bot
 	local traceResult = util.TraceEntity(tracedata,bot)
 	
-	if bot:Alive() and traceResult.StartSolid == true and (traceResult.Entity and not traceResult.Entity:IsWorld())	and (traceResult.Entity and traceResult.Entity:GetClass() == "prop_physics") and GAMEMODE:ShouldCollide(bot, traceResult.Entity) then -- is stuck
+	if bot:Alive() and traceResult.StartSolid == true and traceResult.Entity and not traceResult.Entity:IsWorld() and (traceResult.Entity and traceResult.Entity:GetClass() == "prop_physics") and GAMEMODE:ShouldCollide(bot, traceResult.Entity) and traceResult.Entity:GetCollisionGroup() ~= COLLISION_GROUP_DEBRIS then -- is stuck
 		bot:Kill()
 	end
 	

--- a/lua/d3bot/sv_zs_bot_handler/handlers/undead_fallback.lua
+++ b/lua/d3bot/sv_zs_bot_handler/handlers/undead_fallback.lua
@@ -85,7 +85,8 @@ function HANDLER.ThinkFunction(bot)
 	tracedata.filter = bot
 	local traceResult = util.TraceEntity(tracedata,bot)
 	
-	if bot:Alive() and traceResult.StartSolid == true and traceResult.Entity and not traceResult.Entity:IsWorld() and (traceResult.Entity and traceResult.Entity:GetClass() == "prop_physics") and GAMEMODE:ShouldCollide(bot, traceResult.Entity) and traceResult.Entity:GetCollisionGroup() ~= COLLISION_GROUP_DEBRIS then -- is stuck
+	-- Workaround for bots phasing through barricades in some versions of the gamemode
+	if bot:Alive() and traceResult.StartSolid == true and traceResult.Entity and not traceResult.Entity:IsWorld() and (traceResult.Entity and traceResult.Entity:GetClass() == "prop_physics") and GAMEMODE:ShouldCollide(bot, traceResult.Entity) and traceResult.Entity:GetCollisionGroup() ~= COLLISION_GROUP_DEBRIS and traceResult.Entity:IsNailed() then -- is stuck
 		bot:Kill()
 	end
 	

--- a/lua/d3bot/sv_zs_bot_handler/handlers/undead_fallback.lua
+++ b/lua/d3bot/sv_zs_bot_handler/handlers/undead_fallback.lua
@@ -86,8 +86,13 @@ function HANDLER.ThinkFunction(bot)
 	local traceResult = util.TraceEntity(tracedata,bot)
 	
 	-- Workaround for bots phasing through barricades in some versions of the gamemode
-	if bot:Alive() and traceResult.StartSolid == true and traceResult.Entity and not traceResult.Entity:IsWorld() and (traceResult.Entity and traceResult.Entity:GetClass() == "prop_physics") and GAMEMODE:ShouldCollide(bot, traceResult.Entity) and traceResult.Entity:GetCollisionGroup() ~= COLLISION_GROUP_DEBRIS and traceResult.Entity:IsNailed() then -- is stuck
-		bot:Kill()
+	if bot:Alive() and traceResult.StartSolid == true and traceResult.Entity and not traceResult.Entity:IsWorld() and (traceResult.Entity and traceResult.Entity:GetClass() == "prop_physics") and GAMEMODE:ShouldCollide(bot, traceResult.Entity) and traceResult.Entity:GetCollisionGroup() ~= COLLISION_GROUP_DEBRIS and traceResult.Entity:IsNailed() then
+		--bot:Kill()
+		if mem.LastValidPos then
+			bot:SetPos(mem.LastValidPos)
+		end
+	elseif bot:Alive() then
+		mem.LastValidPos = botPos
 	end
 	
 	if mem.nextUpdateSurroundingPlayers and mem.nextUpdateSurroundingPlayers < CurTime() or not mem.nextUpdateSurroundingPlayers then

--- a/lua/d3bot/sv_zs_bot_handler/handlers/undead_fallback.lua
+++ b/lua/d3bot/sv_zs_bot_handler/handlers/undead_fallback.lua
@@ -85,10 +85,8 @@ function HANDLER.ThinkFunction(bot)
 	tracedata.filter = bot
 	local traceResult = util.TraceEntity(tracedata,bot)
 	
-	if bot:Alive() and traceResult.StartSolid == true and (traceResult.Entity and not traceResult.Entity:IsWorld())
-	and (traceResult.Entity and (not traceResult.Entity.IsPlayer or not traceResult.Entity:IsPlayer()) and traceResult.Entity:GetClass() ~= "prop_obj_exit" and traceResult.Entity:GetClass() ~= "prop_obj_sigil") then -- is stuck
+	if bot:Alive() and traceResult.StartSolid == true and (traceResult.Entity and not traceResult.Entity:IsWorld())	and (traceResult.Entity and traceResult.Entity:GetClass() == "prop_physics") and GAMEMODE:ShouldCollide(bot, traceResult.Entity) then -- is stuck
 		bot:Kill()
-		return
 	end
 	
 	if mem.nextUpdateSurroundingPlayers and mem.nextUpdateSurroundingPlayers < CurTime() or not mem.nextUpdateSurroundingPlayers then

--- a/lua/d3bot/sv_zs_bot_handler/handlers/undead_fallback.lua
+++ b/lua/d3bot/sv_zs_bot_handler/handlers/undead_fallback.lua
@@ -85,8 +85,10 @@ function HANDLER.ThinkFunction(bot)
 	tracedata.filter = bot
 	local traceResult = util.TraceEntity(tracedata,bot)
 	
-	if bot:Alive() and traceResult.StartSolid == true and (traceResult.Entity and not traceResult.Entity:IsWorld()) and (traceResult.Entity and (not traceResult.Entity.IsPlayer or not traceResult.Entity:IsPlayer()) ) then -- is stuck
+	if bot:Alive() and traceResult.StartSolid == true and (traceResult.Entity and not traceResult.Entity:IsWorld())
+	and (traceResult.Entity and (not traceResult.Entity.IsPlayer or not traceResult.Entity:IsPlayer()) and traceResult.Entity:GetClass() ~= "prop_obj_exit" and traceResult.Entity:GetClass() ~= "prop_obj_sigil") then -- is stuck
 		bot:Kill()
+		return
 	end
 	
 	if mem.nextUpdateSurroundingPlayers and mem.nextUpdateSurroundingPlayers < CurTime() or not mem.nextUpdateSurroundingPlayers then


### PR DESCRIPTION
On certain situations bots can get stuck inside a barricade's prop, which will lead to him being able to move through the cade, to prevent this I've added a trace call that detects if this is happening and kills the bot on the spot.

Only issue with this is that rarely a zombie ends up spawning exactly where it died, I could be placing it at the wrong place but I'm pretty sure you'd know the right place to add this piece of code.