### PR TITLE
WIP: Attempt to stop bots from moving when stuck inside a prop

### DIFF
--- a/lua/d3bot/sh_utilities.lua
+++ b/lua/d3bot/sh_utilities.lua
@@ -15,6 +15,16 @@ function D3bot.GetTrajectories2DParams(g, initVel, distZ, distRad)
 	return trajectories
 end
 
+function D3bot.IsBotStuck(bot) 
+	local botPos = bot:GetPos()
+	local tracedata = {start=nil,endpos=nil,mask=MASK_PLAYERSOLID,filter=nil}
+	tracedata.start = bot:GetPos()
+	tracedata.endpos = tracedata.start
+	tracedata.filter = bot
+	local traceResult = util.TraceEntity(tracedata,bot)
+	return bot:Alive() and traceResult and traceResult.StartSolid == true and not traceResult.Entity:IsWorld() and (traceResult.Entity:IsValid() and traceResult.Entity:GetClass() == "prop_physics") and traceResult.Entity:GetCollisionGroup() ~= COLLISION_GROUP_DEBRIS and traceResult.Entity:IsNailed()
+end
+
 function D3bot.GetTrajectory2DPoints(trajectory, segments)
 	trajectory.points = {}
 	for i = 0, segments, 1 do


### PR DESCRIPTION
I've tried everything to stop bots from phasing through props, I wasn't able to identify the issue within the game mode's file.

I have done some attempts to fix but currently nothing works. 
**Attempts I've done to circumvent the issue:** 
-  Tried counting the number of times a bot get's stuck and freezing them which didn't work either, since apparently the trace sometimes doesn't detect the player
- Saving the the older `lastPos` saved when a new one is assigned, in an attempt to place the bot further away from the cade and not immediately on a position where it's going to get stuck again
- Resetting the bot's velocity and `movetype` to avoid him immediately getting stuck again

The only real solution I can think of is to command the bot to stop trying to move once he's stuck inside a prop, therefore avoiding him from just walking off from inside the prop towards the player.  Though I'm not sure exactly on how to do this.

The perfect place to reproduce this issue is to nail a prop directly in front of gmod_construct secret room's ladder.