### PR TITLE
Add convar to limit navmesh drawing distance

### DIFF
--- a/lua/d3bot/1_navmesh.lua
+++ b/lua/d3bot/1_navmesh.lua
@@ -143,9 +143,9 @@ return function(lib)
 		if nilOrNodeB == nil then
 			local id = idOrNodeA
 			local serializedNodeIds = id:Split(lib.NavMeshLinkNodesSeparator)
-			if #serializedNodeIds != 2 then error("Link must have exactly 2 nodes to link.", 2) end
+			if #serializedNodeIds ~= 2 then error("Link must have exactly 2 nodes to link.", 2) end
 			local nodeIds = from(serializedNodeIds):SelV(tonumber).R
-			if from(nodeIds):Len().R != 2 then error("Invalid node ID.", 2) end
+			if from(nodeIds):Len().R ~= 2 then error("Invalid node ID.", 2) end
 			nodeA, nodeB = unpack(from(nodeIds):SelV(function(nodeId) return self:ForceGetNode(nodeId) end).R)
 		else
 			nodeA = idOrNodeA
@@ -229,17 +229,27 @@ return function(lib)
 	
 	function fallback:GetCursoredItemOrNil(pl)
 		local oldDraw = pl:GetInfoNum("d3bot_navmeshing_smartdraw", 1) == 0
+		local maxDrawingDistance = pl:GetInfoNum("d3bot_navmeshing_drawdistance", 0)
 		local relAngMin = 5
 		local cursoredItemOrNil
 		local eyePos, eyeAngs = pl:EyePos(), pl:EyeAngles()
+		local inViewRange = true
 		for id, item in pairs(self.ItemById) do
-			local angs = (item:GetFocusPos() - eyePos):Angle()
-			local relP = math.AngleDifference(eyeAngs.p, angs.p)
-			local relY = math.AngleDifference(eyeAngs.y, angs.y)
-			local relAng = math.sqrt(relP * relP + relY * relY)
-			if relAng < relAngMin and (oldDraw or item:ShouldDraw(eyePos)) then
-				cursoredItemOrNil = item
-				relAngMin = relAng
+			if maxDrawingDistance > 0 then
+				inViewRange = item:GetFocusPos():Distance(eyePos) <= maxDrawingDistance
+			end
+
+			if inViewRange then
+				if oldDraw or item:ShouldDraw(eyePos) then
+					local angs = (item:GetFocusPos() - eyePos):Angle()
+					local relP = math.AngleDifference(eyeAngs.p, angs.p)
+					local relY = math.AngleDifference(eyeAngs.y, angs.y)
+					local relAng = math.sqrt(relP * relP + relY * relY)
+					if relAng < relAngMin then
+						cursoredItemOrNil = item
+						relAngMin = relAng
+					end
+				end
 			end
 		end
 		return cursoredItemOrNil

--- a/lua/d3bot/1_navmesh.lua
+++ b/lua/d3bot/1_navmesh.lua
@@ -240,15 +240,13 @@ return function(lib)
 			end
 
 			if inViewRange then
-				if oldDraw or item:ShouldDraw(eyePos) then
-					local angs = (item:GetFocusPos() - eyePos):Angle()
-					local relP = math.AngleDifference(eyeAngs.p, angs.p)
-					local relY = math.AngleDifference(eyeAngs.y, angs.y)
-					local relAng = math.sqrt(relP * relP + relY * relY)
-					if relAng < relAngMin then
-						cursoredItemOrNil = item
-						relAngMin = relAng
-					end
+				local angs = (item:GetFocusPos() - eyePos):Angle()
+				local relP = math.AngleDifference(eyeAngs.p, angs.p)
+				local relY = math.AngleDifference(eyeAngs.y, angs.y)
+				local relAng = math.sqrt(relP * relP + relY * relY)
+				if relAng < relAngMin and (oldDraw or item:ShouldDraw(eyePos)) then
+					cursoredItemOrNil = item
+					relAngMin = relAng
 				end
 			end
 		end

--- a/lua/d3bot/2_mapnavmeshui_cl.lua
+++ b/lua/d3bot/2_mapnavmeshui_cl.lua
@@ -153,13 +153,10 @@ return function(lib)
 					cam.IgnoreZ(false)
 				end
 
-				local inViewRange = true
+				local maxDrawingDistance = math.min(D3bot.Convar_Navmeshing_DrawDistance:GetInt(), 500)
+				if maxDrawingDistance <= 0 then maxDrawingDistance = 500 end
 				for id, node in pairs(lib.MapNavMesh.NodeById) do
-					if maxDrawingDistance > 0 then
-						inViewRange = node.Pos:Distance(eyePos) <= maxDrawingDistance
-					end
-
-					if node.HasArea and node.Pos:Distance(eyePos) < 500 and inViewRange and (not smartDraw or isNodeIdVisible(id)) then
+					if node.HasArea and node.Pos:Distance(eyePos) <= maxDrawingDistance and (not smartDraw or isNodeIdVisible(id)) then
 						local z = node.Pos.z + 0.2
 						local params = node.Params
 						local color = getOutlineColor(node)
@@ -184,12 +181,14 @@ return function(lib)
 			end)
 			hook.Add("HUDPaint", hooksId, function()
 				local smartDraw = D3bot.Convar_Navmeshing_SmartDraw:GetBool()
+				local maxDrawingDistance = math.min(D3bot.Convar_Navmeshing_DrawDistance:GetInt(), 500)
+				if maxDrawingDistance <= 0 then maxDrawingDistance = 500 end
 				surface.SetFont("Default")
 				local eyePos = EyePos()
 				for id, item in pairs(lib.MapNavMesh.ItemById) do
 					local isCursored = item == cursoredItemOrNil
 					local itemPos = item:GetFocusPos()
-					if isCursored or itemPos:Distance(eyePos) <= 500 then
+					if isCursored or itemPos:Distance(eyePos) <= maxDrawingDistance then
 						local pos = itemPos:ToScreen()
 						if pos.visible and (not smartDraw or isNodeIdVisible(id)) then
 							local paramsQuery = from(item.Params)

--- a/lua/d3bot/2_mapnavmeshui_cl.lua
+++ b/lua/d3bot/2_mapnavmeshui_cl.lua
@@ -90,52 +90,76 @@ return function(lib)
 				end
 				forceDrawInSkyboxCounter = 0
 				local smartDraw = D3bot.Convar_Navmeshing_SmartDraw:GetBool()
+				local maxDrawingDistance = D3bot.Convar_Navmeshing_DrawDistance:GetInt()
 				local eyePos = EyePos()
 				render.SetColorMaterial()
 				if not smartDraw then
 					cam.IgnoreZ(true)
 				end
+
+				local inViewRange = true
 				for id, node in pairs(lib.MapNavMesh.NodeById) do
-					if smartDraw and isNodeIdHighlightedOrSelected(id) then
-						cam.IgnoreZ(true)
+					if maxDrawingDistance > 0 then
+						inViewRange = node.Pos:Distance(eyePos) <= maxDrawingDistance
 					end
-					if not smartDraw or isNodeIdVisible(id) then
-						if node.HasArea then
-							local z = node.Pos.z + 0.2
-							local params = node.Params
-							for k, cullMode in ipairs{ MATERIAL_CULLMODE_CW, MATERIAL_CULLMODE_CCW } do
-								render.CullMode(cullMode)
-								render.DrawQuad(
-									Vector(params.AreaXMin, params.AreaYMin, z),
-									Vector(params.AreaXMin, params.AreaYMax, z),
-									Vector(params.AreaXMax, params.AreaYMax, z),
-									Vector(params.AreaXMax, params.AreaYMin, z),
-									getItemColor(node).EightAlpha)
-							end
+
+					if inViewRange or isNodeIdHighlightedOrSelected(id) then
+						if smartDraw and isNodeIdHighlightedOrSelected(id) then
+							cam.IgnoreZ(true)
 						end
-						render.DrawSphere(node.Pos, 2, 8, 8, getItemColor(node))
-					end
-					if smartDraw and isNodeIdHighlightedOrSelected(id) then
-						cam.IgnoreZ(false)
+						if not smartDraw or isNodeIdVisible(id) then
+							if node.HasArea then
+								local z = node.Pos.z + 0.2
+								local params = node.Params
+								for k, cullMode in ipairs{ MATERIAL_CULLMODE_CW, MATERIAL_CULLMODE_CCW } do
+									render.CullMode(cullMode)
+									render.DrawQuad(
+										Vector(params.AreaXMin, params.AreaYMin, z),
+										Vector(params.AreaXMin, params.AreaYMax, z),
+										Vector(params.AreaXMax, params.AreaYMax, z),
+										Vector(params.AreaXMax, params.AreaYMin, z),
+										getItemColor(node).EightAlpha)
+								end
+							end
+							render.DrawSphere(node.Pos, 2, 8, 8, getItemColor(node))
+						end
+						if smartDraw and isNodeIdHighlightedOrSelected(id) then
+							cam.IgnoreZ(false)
+						end
 					end
 				end
+
+				local inViewRange = true
 				for id, link in pairs(lib.MapNavMesh.LinkById) do
 					local nodeA, nodeB = unpack(link.Nodes)
-					if smartDraw and isNodeIdHighlightedOrSelected(id) then
-						cam.IgnoreZ(true)
+					if maxDrawingDistance > 0 then
+						inViewRange = link:GetFocusPos():Distance(eyePos) <= maxDrawingDistance
 					end
-					if not smartDraw or isNodeIdVisible(nodeA.Id) and isNodeIdVisible(nodeB.Id) then
-						render.DrawBeam(nodeA.Pos + Vector(0, 0, 1), nodeB.Pos + Vector(0, 0, 1), 1, 0, 1, getItemColor(link))
-					end
-					if smartDraw and isNodeIdHighlightedOrSelected(id) then
-						cam.IgnoreZ(false)
+
+					if inViewRange or isNodeIdHighlightedOrSelected(id) then
+						if smartDraw and isNodeIdHighlightedOrSelected(id) then
+							cam.IgnoreZ(true)
+						end
+						if not smartDraw or isNodeIdVisible(nodeA.Id) and isNodeIdVisible(nodeB.Id) then
+							render.DrawBeam(nodeA.Pos + Vector(0, 0, 1), nodeB.Pos + Vector(0, 0, 1), 1, 0, 1, getItemColor(link))
+						end
+						if smartDraw and isNodeIdHighlightedOrSelected(id) then
+							cam.IgnoreZ(false)
+						end
 					end
 				end
+
 				if not smartDraw then
 					cam.IgnoreZ(false)
 				end
+
+				local inViewRange = true
 				for id, node in pairs(lib.MapNavMesh.NodeById) do
-					if node.HasArea and node.Pos:Distance(eyePos) < 500 and (not smartDraw or isNodeIdVisible(id)) then
+					if maxDrawingDistance > 0 then
+						inViewRange = node.Pos:Distance(eyePos) <= maxDrawingDistance
+					end
+
+					if node.HasArea and node.Pos:Distance(eyePos) < 500 and inViewRange and (not smartDraw or isNodeIdVisible(id)) then
 						local z = node.Pos.z + 0.2
 						local params = node.Params
 						local color = getOutlineColor(node)

--- a/lua/d3bot/cl_convars.lua
+++ b/lua/d3bot/cl_convars.lua
@@ -3,3 +3,4 @@ CreateClientConVar("d3bot_navmeshing_mode", "", true, true, "Defines the navmesh
 CreateClientConVar("d3bot_navmeshing_reloadmodecycle", 1, true, true, "Defines if the client is in the navmeshing mode.")
 
 D3bot.Convar_Navmeshing_SmartDraw = CreateClientConVar("d3bot_navmeshing_smartdraw", 1, true, true, "Automatically hides obscured nodes and links.")
+D3bot.Convar_Navmeshing_DrawDistance = CreateClientConVar("d3bot_navmeshing_drawdistance", 0, true, true, "The maximum drawing distance. Use 0 to disable this option.")


### PR DESCRIPTION

- `d3bot_navmeshing_drawdistance 1000` to limit drawing to 1000 source engine units.
- `d3bot_navmeshing_drawdistance 0` to disable the limit.

Fixes #50