### PR TITLE
Preload function Distance

### DIFF
--- a/lua/d3bot/sv_path.lua
+++ b/lua/d3bot/sv_path.lua
@@ -1,6 +1,7 @@
 local mathMax = math.max
 local mathHuge = math.huge
 local tableInsert = table.insert
+local Distance = FindMetaTable("Vector").Distance
 
 local function create_path_cache()
 	local tostring = tostring
@@ -117,12 +118,12 @@ function D3bot.GetBestMeshPathOrNil(startNode, endNode, pathCostFunction, heuris
 
 			if able and not blocked and not (linkParams.Direction == "Forward" and link.Nodes[2] == node) and
 				not (linkParams.Direction == "Backward" and link.Nodes[1] == node) then
-				local linkedNodePathCost = minimalPathCostByNode[node] + mathMax(node.Pos:Distance(linkedNode.Pos) + (linkedNodeParams.Cost or 0) + (linkParams.Cost or 0) + (pathCostFunction and pathCostFunction(node, linkedNode, link) or 0), 0) -- Prevent negative change of the link costs, otherwise it will get stuck decreasing forever.
+				local linkedNodePathCost = minimalPathCostByNode[node] + mathMax(Distance(node.Pos, linkedNode.Pos) + (linkedNodeParams.Cost or 0) + (linkParams.Cost or 0) + (pathCostFunction and pathCostFunction(node, linkedNode, link) or 0), 0) -- Prevent negative change of the link costs, otherwise it will get stuck decreasing forever.
 				if linkedNodePathCost < (minimalPathCostByNode[linkedNode] or mathHuge) then
 					entranceByNode[linkedNode] = node
 					minimalPathCostByNode[linkedNode] = linkedNodePathCost
 					local heuristic = (heuristicCostFunction and heuristicCostFunction(linkedNode) or 0)
-					minimalTotalPathCostByNode[linkedNode] = linkedNodePathCost + heuristic + linkedNode.Pos:Distance(endNode.Pos) -- Negative costs are allowed here.
+					minimalTotalPathCostByNode[linkedNode] = linkedNodePathCost + heuristic + Distance(linkedNode.Pos, endNode.Pos) -- Negative costs are allowed here.
 					evaluationNodeQueue:Enqueue(linkedNode)
 				end
 			end
@@ -178,12 +179,12 @@ function D3bot.GetBestValveMeshPathOrNil( startArea, endArea, pathCostFunction, 
 			if linkedAreaData.Params.Climbing == "Needed" and abilities and not abilities.Climb then able = false end
 			
 			if able and not blocked then
-				local newCostSoFar = current:GetCostSoFar() + math.max( current:GetCenter():Distance( linkedArea:GetCenter() ) + ( ( linkedAreaData.Params.Cost and current:GetCostSoFar() / 4 ) or 0 ) + ( ( linkData.Params.Cost and current:GetCostSoFar() / 4 ) or 0 ) + ( pathCostFunction and pathCostFunction( current, linkedArea, link ) or 0 ), 0 )
+				local newCostSoFar = current:GetCostSoFar() + math.max( Distance(current:GetCenter(), linkedArea:GetCenter() ) + ( ( linkedAreaData.Params.Cost and current:GetCostSoFar() / 4 ) or 0 ) + ( ( linkData.Params.Cost and current:GetCostSoFar() / 4 ) or 0 ) + ( pathCostFunction and pathCostFunction( current, linkedArea, link ) or 0 ), 0 )
 				if not ( linkedArea:IsOpen() or linkedArea:IsClosed() and linkedArea:GetCostSoFar() <= newCostSoFar ) then
 					cameFrom[ linkedArea:GetID() ] = current:GetID()
 					linkedArea:SetCostSoFar( newCostSoFar )
 					local heuristic = ( heuristicCostFunction and heuristicCostFunction( linkedArea ) or 0 )
-					linkedArea:SetTotalCost( newCostSoFar + heuristic + linkedArea:GetCenter():Distance( endArea:GetCenter() ) )  -- Negative costs are allowed here
+					linkedArea:SetTotalCost( newCostSoFar + heuristic + Distance(linkedArea:GetCenter(), endArea:GetCenter() ) )  -- Negative costs are allowed here
 					if linkedArea:IsClosed() then
 						linkedArea:RemoveFromClosedList()
 					end
@@ -321,7 +322,7 @@ function D3bot.GetEscapeValveMeshPathOrNil( startArea, iterations, pathCostFunct
 			if linkedAreaData.Params.Climbing == "Needed" and abilities and not abilities.Climb then able = false end
 		
 			if able and not blocked then
-				local newCostSoFar = current:GetCostSoFar() + math.max( current:GetCenter():Distance( linkedArea:GetCenter() ) + ( ( linkedAreaData.Params.Cost and current:GetCostSoFar() / 4 ) or 0 ) + ( ( linkData.Params.Cost and current:GetCostSoFar() / 4 ) or 0 ) + ( pathCostFunction and pathCostFunction( current, linkedArea, link ) or 0 ), 0 )
+				local newCostSoFar = current:GetCostSoFar() + math.max( Distance(current:GetCenter(), linkedArea:GetCenter() ) + ( ( linkedAreaData.Params.Cost and current:GetCostSoFar() / 4 ) or 0 ) + ( ( linkData.Params.Cost and current:GetCostSoFar() / 4 ) or 0 ) + ( pathCostFunction and pathCostFunction( current, linkedArea, link ) or 0 ), 0 )
 				if not ( linkedArea:IsOpen() or linkedArea:IsClosed() and linkedArea:GetCostSoFar() <= newCostSoFar ) then
 					if linkedArea:IsClosed() then
 						linkedArea:RemoveFromClosedList()

--- a/lua/d3bot/sv_path.lua
+++ b/lua/d3bot/sv_path.lua
@@ -3,45 +3,6 @@ local mathHuge = math.huge
 local tableInsert = table.insert
 local Distance = FindMetaTable("Vector").Distance
 
-local function create_path_cache()
-	local tostring = tostring
-  local cache = {}
-  local MAX_CACHE_SIZE = 30
-
-  local function add_path(self, start_node, end_node, a_Walk, a_Pounce, a_Climb, path)
-    local key = tostring(start_node) .. "-" .. tostring(end_node) .. "-" .. tostring(a_Walk) .. "-" .. tostring(a_Pounce) .. "-" .. tostring(a_Climb)
-    if cache[key] then
-      return
-    end
-
-    if #self >= MAX_CACHE_SIZE then
-        cache[self[1]] = nil
-        for i=1, MAX_CACHE_SIZE-1 do
-            self[i] = self[i+1]
-        end
-        self[MAX_CACHE_SIZE] = nil
-    end
-    self[#self+1] = key
-    cache[key] = path
-  end
-
-  local function get_path(self, start_node, end_node, a_Walk, a_Pounce, a_Climb)
-    local key = tostring(start_node) .. "-" .. tostring(end_node) .. "-" .. tostring(a_Walk) .. "-" .. tostring(a_Pounce) .. "-" .. tostring(a_Climb)
-    return cache[key]
-  end
-
-  local mt = {
-    __index = {
-      add_path = add_path,
-      get_path = get_path,
-    },
-  }
-
-  return setmetatable({}, mt)
-end
-
-local path_cache = create_path_cache()
-
 ---Returns the best path (or nil if there is no possible path) between startNode and endNode.
 ---@param startNode any
 ---@param endNode any
@@ -52,8 +13,6 @@ local path_cache = create_path_cache()
 function D3bot.GetBestMeshPathOrNil(startNode, endNode, pathCostFunction, heuristicCostFunction, abilities)
 	local a_Walk, a_Pounce, a_Climb = abilities.Walk, abilities.Pounce, abilities.Climb
 	local wave = GAMEMODE:GetWave()
-	cached_path1 = path_cache:get_path(startNode, endNode, a_Walk, a_Pounce, a_Climb)
-	if cached_path1 then return cached_path1 end
 	-- See: https://en.wikipedia.org/wiki/A*_search_algorithm
 
 	-- Benchmarks:
@@ -83,7 +42,6 @@ function D3bot.GetBestMeshPathOrNil(startNode, endNode, pathCostFunction, heuris
 				if not node then break end
 				tableInsert(path, 1, node)
 			end
-			path_cache:add_path(startNode, endNode, a_Walk, a_Pounce, a_Climb, path)
 			return path
 		end
 


### PR DESCRIPTION
I preloaded the Distance function, it should speed up the calculations a bit. (I couldn't measure if it got better/worse)

Also added a "simple" path cache so that when bots travel short distances or use the same path, they can use the already "cached" version.
If there is no RAM limitation, you can increase the MAX_CACHE_SIZE to save more paths.
I also took the GAMEMODE:GetWave() out of the loop in this function.

Why not use DistToSqr instead of Distance?
With DistToSqr, calculations will definitely be much faster, I tested this.
But I can't say exactly how well the bots will work with this replacement.