### PR TITLE
Fixed botmod convar throwing an error if set via console...

### DIFF
--- a/lua/ulx/modules/sh/d3bot.lua
+++ b/lua/ulx/modules/sh/d3bot.lua
@@ -131,7 +131,12 @@ registerAdminCmd("BotMod", numParam, function(caller, num)
 	local formerZombiesCountAddition = D3bot.ZombiesCountAddition
 	D3bot.ZombiesCountAddition = math.Round(num)
 	local function format(num) return "[formula + (" .. num .. ")]" end
-	caller:ChatPrint("Zombies count changed from " .. format(formerZombiesCountAddition) .. " to " .. format(D3bot.ZombiesCountAddition) .. ".")
+	if IsValid(caller) then
+		caller:ChatPrint("Zombies count changed from " .. format(formerZombiesCountAddition) .. " to " .. format(D3bot.ZombiesCountAddition) .. ".")
+	else
+		-- If 'botmod' is set via console (or the caller is invalid?), it won't throw an error
+		print("Zombies count changed from " .. format(formerZombiesCountAddition) .. " to " .. format(D3bot.ZombiesCountAddition) .. ".")
+	end
 end)
 
 registerSuperadminCmd("ViewMesh", plsParam, function(caller, pls) for k, pl in pairs(pls) do D3bot.SetMapNavMeshUiSubscription(pl, "view") end end)


### PR DESCRIPTION
...or if the caller is invalid (which should never happen)

Yes, I know other commands suffer from the error but I don't see anyone editing navmeshes from a developer console. BotMod is the only reasonable command to set from it.

Fixes this error:
```lua
[d3bot] addons/d3bot/lua/ulx/modules/sh/d3bot.lua:134: attempt to call method 'ChatPrint' (a nil value)
  1. call - addons/d3bot/lua/ulx/modules/sh/d3bot.lua:134
   2. __fn - addons/ulib/lua/ulib/shared/commands.lua:951
    3. execute - addons/ulib/lua/ulib/shared/commands.lua:1331
     4. unknown - addons/ulib/lua/ulib/shared/commands.lua:1358
      5. unknown - lua/includes/modules/concommand.lua:54```