### PR TITLE
Fixed Turkish Lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Here is a list of notable changes compared to the original version:
   - Portuguese(Brazil) (Thanks to GMBR | $herlock Bu$ter)
   - Russian (Thanks to [Blueberryy])
   - Spanish (Thanks to [Fafy2801])
-  - Turkish (Thanks to ᴇXғɪʀᴇᴄʜʀᴏᴍᴇ~)
+  - Turkish (Thanks to ᴇXғɪʀᴇᴄʜʀᴏᴍᴇ~ and [NovaDiablox])
   - Ukrainian (Thanks to [ErickMaksimets])
 - Some smaller things I possibly forgot.
 
@@ -227,6 +227,7 @@ Starting with highest public priority:
 [Fafy2801]: https://github.com/Fafy2801
 [Halamix2]: https://github.com/Halamix2
 [Half1569]: https://github.com/Half1569
+[NovaDiablox]: https://github.com/NovaDiablox
 [orecros]: https://github.com/orecros
 [Sigilmare]: https://github.com/Sigilmare
 [Wolfaloo]: https://github.com/Wolfaloo

--- a/lua/zombiesurvival/gamemode/languages/d3bot_turkish.lua
+++ b/lua/zombiesurvival/gamemode/languages/d3bot_turkish.lua
@@ -1,12 +1,13 @@
+
 translate.AddLanguage("tr", "Turkish")
 
-LANGUAGE.D3bot_redeemwave           = "Kurtulan olarak oynamak için %u dalgasından önce insan yazabilirsiniz."
+LANGUAGE.D3bot_redeemwave           = "Kurtulan olarak oynamak için %u dalgasından önce '!human' yazabilirsiniz."
 LANGUAGE.D3bot_botmapsonly          = "Bu komut yalnızca bot haritalarında etkindir!"
-LANGUAGE.D3bot_toolate              = "Kendi kendini kurtarmak için çok geç (sadece %u dalgasından önce yapılabilir)."
+LANGUAGE.D3bot_toolate              = "Kendini diriltmek için çok geç (sadece %u dalgasından önce yapılabilir)."
 LANGUAGE.D3bot_alreadyhum           = "Zaten insansın!"
-LANGUAGE.D3bot_noredeemlasthuman    = "Sadece bir kurtulan kaldı, artık kendini kullanamazsın!"
+LANGUAGE.D3bot_noredeemlasthuman    = "Sadece bir kurtulan kaldı, artık kendini diriltemezsin!"
 LANGUAGE.D3bot_noredeemzombieescape = "Bu komut zombi kaçış haritalarında devre dışı bırakıldı!"
 
-LANGUAGE.D3bot_selfredeemdisabled   = "Kendini kullanma komutu devre dışı!"
-LANGUAGE.D3bot_selfredeemrecenty    = "Son zamanlarda zaten kendi kendine kullanılmışsın. %u saniye sonra tekrar dene!"
-LANGUAGE.D3bot_selfredeemcooldown   = "Kendi kendini kurtardın. Bir sonraki kendi kendini kullanana kadar geçerli bekleme süren %u saniye!"
+LANGUAGE.D3bot_selfredeemdisabled   = "Diriliş komutu devre dışı!"
+LANGUAGE.D3bot_selfredeemrecenty    = "Yakın zamanda zaten kendini dirilttin. %u saniye sonra tekrar dene!"
+LANGUAGE.D3bot_selfredeemcooldown   = "Kendini dirilttin. Bir sonraki dirilişe kadar geçerli bekleme süren %u saniye!"


### PR DESCRIPTION
The current translation was wrong. So I changed it. Previous translator's context was missing and inaccurute.

Previous context "self-redeem" ≠ kurtarmak - kullanmak = saving himself - using himself" Current context "self-redeem" = resurrecting himself - resurrection (respawning)= kendini diriltmek - diriliş

I hope this is understandable. Still much respect to previous translator attempting to translate the text.