### PR TITLE
Expanded support for blocking nodes with arbitrary entity types

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ Be sure to follow all the other necessary steps as described in [#Installation](
     - Condition = Unblocked: Bots will only use this node for pathfinding if there is no entity within a range of one source unit. Detected entities are func_breakable, prop_physics, prop_dynamic, prop_door_rotating, func_door, func_physbox_multiplayer, func_movelinear.
     - Condition = Blocked: Opposite of Unblocked. Use this on breakable pathways.
     - Condition = MapUnblocked: Same as Unblocked, but it excludes objects that could potentially be used in cades.
+	- BlockEntity = Entity types that should disable this node.
+	- BlockRadius = Proximity to node for blocking to occur.
     - BlockBeforeWave: Bots will not use this node for pathfinding until the current wave is greater than or equal to the given value.
     - BlockAfterWave: Bots will not use this node for pathfinding if the current wave is greater than the given value.
     - DMGPerSecond: Apply damage to human players and entities located on this node. Can be disabled globally in `sv_config.lua` by setting `D3bot.DisableNodeDamage = true`.

--- a/lua/d3bot/1_navmesh.lua
+++ b/lua/d3bot/1_navmesh.lua
@@ -58,48 +58,6 @@ return function(lib)
 		classes = { func_breakable = true, prop_dynamic = true, prop_door_rotating = true, func_door = true, func_movelinear = true }
 	}
 
-	---@param nodeParams table
-	---@param nodePos Vector
-	---@param wave number
-	---@return boolean
-	function lib.IsNavMeshNodeBlocked(nodeParams, nodePos, wave)
-		local blocked = false
-
-		if nodeParams.Condition == "Unblocked" or nodeParams.Condition == "Blocked" then
-			local ents = ents.FindInBox(nodePos + lib.NodeBlocking.mins, nodePos + lib.NodeBlocking.maxs)
-			for _, ent in ipairs(ents) do
-				if lib.NodeBlocking.classes[ent:GetClass()] then blocked = true; break end
-			end
-			if nodeParams.Condition == "Blocked" then blocked = not blocked end
-		elseif nodeParams.Condition == "MapUnblocked" then
-			local ents = ents.FindInBox(nodePos + lib.NodeBlockingMap.mins, nodePos + lib.NodeBlockingMap.maxs)
-			for _, ent in ipairs(ents) do
-				if lib.NodeBlockingMap.classes[ent:GetClass()] then blocked = true; break end
-			end
-		end
-
-		if not blocked and nodeParams.BlockEntity then
-			local blockRadius = tonumber(nodeParams.BlockRadius)
-			if blockRadius then
-				for _, ent in ipairs(ents.FindInSphere(nodePos, blockRadius)) do
-					if ent:GetClass() == nodeParams.BlockEntity then
-						blocked = true
-						break
-					end
-				end
-			end
-		end
-
-		if nodeParams.BlockBeforeWave and tonumber(nodeParams.BlockBeforeWave) then
-			if wave < tonumber(nodeParams.BlockBeforeWave) then blocked = true end
-		end
-		if nodeParams.BlockAfterWave and tonumber(nodeParams.BlockAfterWave) then
-			if wave > tonumber(nodeParams.BlockAfterWave) then blocked = true end
-		end
-
-		return blocked
-	end
-
 	lib.Params = {
 		Correct = {
 			Jump = { "Disabled", "Always" },

--- a/lua/d3bot/1_navmesh.lua
+++ b/lua/d3bot/1_navmesh.lua
@@ -47,6 +47,59 @@ return function(lib)
 	lib.NavMeshItemParamNameNumPairSeparator = "="
 	lib.NavMeshLinkNodesSeparator = "-"
 
+	lib.NodeBlocking = {
+		mins = Vector(-1, -1, -1),
+		maxs = Vector(1, 1, 1),
+		classes = { func_breakable = true, prop_physics = true, prop_dynamic = true, prop_door_rotating = true, func_door = true, func_physbox = true, func_physbox_multiplayer = true, func_movelinear = true }
+	}
+	lib.NodeBlockingMap = {
+		mins = Vector(-1, -1, -1),
+		maxs = Vector(1, 1, 1),
+		classes = { func_breakable = true, prop_dynamic = true, prop_door_rotating = true, func_door = true, func_movelinear = true }
+	}
+
+	---@param nodeParams table
+	---@param nodePos Vector
+	---@param wave number
+	---@return boolean
+	function lib.IsNavMeshNodeBlocked(nodeParams, nodePos, wave)
+		local blocked = false
+
+		if nodeParams.Condition == "Unblocked" or nodeParams.Condition == "Blocked" then
+			local ents = ents.FindInBox(nodePos + lib.NodeBlocking.mins, nodePos + lib.NodeBlocking.maxs)
+			for _, ent in ipairs(ents) do
+				if lib.NodeBlocking.classes[ent:GetClass()] then blocked = true; break end
+			end
+			if nodeParams.Condition == "Blocked" then blocked = not blocked end
+		elseif nodeParams.Condition == "MapUnblocked" then
+			local ents = ents.FindInBox(nodePos + lib.NodeBlockingMap.mins, nodePos + lib.NodeBlockingMap.maxs)
+			for _, ent in ipairs(ents) do
+				if lib.NodeBlockingMap.classes[ent:GetClass()] then blocked = true; break end
+			end
+		end
+
+		if not blocked and nodeParams.BlockEntity then
+			local blockRadius = tonumber(nodeParams.BlockRadius)
+			if blockRadius then
+				for _, ent in ipairs(ents.FindInSphere(nodePos, blockRadius)) do
+					if ent:GetClass() == nodeParams.BlockEntity then
+						blocked = true
+						break
+					end
+				end
+			end
+		end
+
+		if nodeParams.BlockBeforeWave and tonumber(nodeParams.BlockBeforeWave) then
+			if wave < tonumber(nodeParams.BlockBeforeWave) then blocked = true end
+		end
+		if nodeParams.BlockAfterWave and tonumber(nodeParams.BlockAfterWave) then
+			if wave > tonumber(nodeParams.BlockAfterWave) then blocked = true end
+		end
+
+		return blocked
+	end
+
 	lib.Params = {
 		Correct = {
 			Jump = { "Disabled", "Always" },
@@ -59,6 +112,8 @@ return function(lib)
 			AimTo = { "Straight" },
 			Cost = {},
 			Condition = { "Unblocked", "Blocked", "MapUnblocked" },
+			BlockEntity = {},
+			BlockRadius = {},
 			BlockBeforeWave = {},
 			BlockAfterWave = {},
 			Direction = { "Forward", "Backward" },

--- a/lua/d3bot/1_navmesh.lua
+++ b/lua/d3bot/1_navmesh.lua
@@ -47,17 +47,6 @@ return function(lib)
 	lib.NavMeshItemParamNameNumPairSeparator = "="
 	lib.NavMeshLinkNodesSeparator = "-"
 
-	lib.NodeBlocking = {
-		mins = Vector(-1, -1, -1),
-		maxs = Vector(1, 1, 1),
-		classes = { func_breakable = true, prop_physics = true, prop_dynamic = true, prop_door_rotating = true, func_door = true, func_physbox = true, func_physbox_multiplayer = true, func_movelinear = true }
-	}
-	lib.NodeBlockingMap = {
-		mins = Vector(-1, -1, -1),
-		maxs = Vector(1, 1, 1),
-		classes = { func_breakable = true, prop_dynamic = true, prop_door_rotating = true, func_door = true, func_movelinear = true }
-	}
-
 	lib.Params = {
 		Correct = {
 			Jump = { "Disabled", "Always" },

--- a/lua/d3bot/1_navmesh_cl.lua
+++ b/lua/d3bot/1_navmesh_cl.lua
@@ -11,6 +11,7 @@ return function(lib)
 		if finished then
 			lib.MapNavMesh = lib.DeserializeNavMesh(util.Decompress(buffer)) or {}
 			buffer = ""
+			if lib.InvalidateMapNavMeshViewBlockedCache then lib.InvalidateMapNavMeshViewBlockedCache() end
 		end
 	end)
 end

--- a/lua/d3bot/2_mapnavmeshui_cl.lua
+++ b/lua/d3bot/2_mapnavmeshui_cl.lua
@@ -208,8 +208,8 @@ return function(lib)
 							end
 							render.DrawSphere(node.Pos, 2, 8, 8, getItemColor(node))
 							local blockRadius = tonumber(node.Params.BlockRadius)
-							if blockRadius and node.Params.BlockEntity and blockedNodeById[id] then
-								render.DrawWireframeSphere(node.Pos, blockRadius, 12, 12, lib.Color.Blocked.HalfAlpha, true)
+							if blockRadius and node.Params.BlockEntity then
+								render.DrawWireframeSphere(node.Pos, blockRadius, 12, 12, blockedNodeById[id] and lib.Color.Blocked or lib.Color.Blocked.HalfAlpha, true)
 							end
 						end
 						if smartDraw and isNodeIdHighlightedOrSelected(id) then

--- a/lua/d3bot/2_mapnavmeshui_cl.lua
+++ b/lua/d3bot/2_mapnavmeshui_cl.lua
@@ -25,14 +25,64 @@ return function(lib)
 	local selectedNodeIDs = {} -- Contains the same information as `isHighlightedById`, but is sorted by selection order.
 	function lib.HighlightInMapNavMeshView(id) isHighlightedById[id] = true table.insert(selectedNodeIDs, id) end
 	function lib.ClearMapNavMeshViewHighlights() isHighlightedById, selectedNodeIDs = {}, {} end
-	
-	local function getItemColor(item) return lib.Color[isHighlightedById[item.Id] and "Green" or (item == cursoredItemOrNil and "Orange" or (isPathPieceById[item.Id] and "Yellow" or "Red"))] end
-	local function getOutlineColor(item) return lib.Color[isHighlightedById[item.Id] and "Green" or (item == cursoredItemOrNil and "Orange" or "Black")] end
-	
+
 	local isHiddenParamByParamName = from((" "):Explode("X Y Z AreaXMin AreaYMin AreaXMax AreaYMax")):VsSet().R
-	
+
 	local nodeVisualProperties = {}
 	local nodeVisualPropertiesQueue = {}
+
+	local blockedNodeById = {}
+	local blockedNodeUpdateQueue = {}
+
+	function lib.InvalidateMapNavMeshViewBlockedCache()
+		blockedNodeById = {}
+		blockedNodeUpdateQueue = {}
+	end
+
+	local function getPathfindingWave()
+		return (GAMEMODE and GAMEMODE.GetWave and GAMEMODE:GetWave()) or 0
+	end
+
+	local function updateBlockedNodeCache(batchSize)
+		if not lib.MapNavMesh or not lib.MapNavMesh.NodeById then return end
+		if #blockedNodeUpdateQueue == 0 then
+			for id in pairs(lib.MapNavMesh.NodeById) do
+				table.insert(blockedNodeUpdateQueue, id)
+			end
+		end
+		local wave = getPathfindingWave()
+		for i = 1, batchSize do
+			local id = table.remove(blockedNodeUpdateQueue, 1)
+			if not id then break end
+			local node = lib.MapNavMesh.NodeById[id]
+			blockedNodeById[id] = node and lib.IsNavMeshNodeBlocked(node.Params, node.Pos, wave) or false
+			table.insert(blockedNodeUpdateQueue, id)
+		end
+	end
+
+	local function isItemPathBlocked(item)
+		if item.Type == "node" then
+			return blockedNodeById[item.Id] == true
+		end
+		if item.Type == "link" then
+			local nodeA, nodeB = unpack(item.Nodes)
+			return blockedNodeById[nodeA.Id] or blockedNodeById[nodeB.Id]
+		end
+	end
+
+	local function getItemColor(item)
+		if isHighlightedById[item.Id] then return lib.Color.Green end
+		if item == cursoredItemOrNil then return lib.Color.Orange end
+		if isPathPieceById[item.Id] then return lib.Color.Yellow end
+		if isItemPathBlocked(item) then return lib.Color.Blocked end
+		return lib.Color.Red
+	end
+	local function getOutlineColor(item)
+		if isHighlightedById[item.Id] then return lib.Color.Green end
+		if item == cursoredItemOrNil then return lib.Color.Orange end
+		if isItemPathBlocked(item) then return lib.Color.Blocked end
+		return lib.Color.Black
+	end
 	
 	local function isNodeIdHighlightedOrSelected(id) return isHighlightedById[id] or (cursoredItemOrNil and cursoredItemOrNil.Id == id) end
 	local function isNodeIdVisible(id) return isNodeIdHighlightedOrSelected(id) or nodeVisualProperties[id] and not nodeVisualProperties[id].ShouldHide end
@@ -75,8 +125,10 @@ return function(lib)
 		isEnabled = bool
 		if isEnabled then
 			nodeVisualProperties = {}
+			lib.InvalidateMapNavMeshViewBlockedCache()
 			hook.Add("Think", hooksId, function()
 				cursoredItemOrNil = lib.MapNavMesh:GetCursoredItemOrNil(LocalPlayer())
+				updateBlockedNodeCache(20)
 				
 				local smartDraw = D3bot.Convar_Navmeshing_SmartDraw:GetBool()
 				if smartDraw then
@@ -155,6 +207,10 @@ return function(lib)
 								end
 							end
 							render.DrawSphere(node.Pos, 2, 8, 8, getItemColor(node))
+							local blockRadius = tonumber(node.Params.BlockRadius)
+							if blockRadius and node.Params.BlockEntity and blockedNodeById[id] then
+								render.DrawWireframeSphere(node.Pos, blockRadius, 12, 12, lib.Color.Blocked.HalfAlpha, true)
+							end
 						end
 						if smartDraw and isNodeIdHighlightedOrSelected(id) then
 							cam.IgnoreZ(false)
@@ -448,6 +504,9 @@ return function(lib)
 							local paramsQuery = from(item.Params)
 							if not isCursored then paramsQuery:Where(function(name) return not isHiddenParamByParamName[name] end) end
 							local txt = item.Id .. ":\n" .. paramsQuery:Sel(function(name, v) return nil, name .. " = " .. v end):Sort():Join("\n").R
+							if item.Type == "node" and blockedNodeById[item.Id] then
+								txt = txt .. "\n[BLOCKED]"
+							end
 							local txtW, txtH = surface.GetTextSize(txt)
 							local w = txtW + 10
 							local h = txtH + 10
@@ -466,6 +525,7 @@ return function(lib)
 				end
 			end)
 		else
+			lib.InvalidateMapNavMeshViewBlockedCache()
 			hook.Remove("Think", hooksId)
 			hook.Remove("PostDrawOpaqueRenderables", hooksId)
 			hook.Remove("HUDPaint", hooksId)

--- a/lua/d3bot/2_mapnavmeshui_cl.lua
+++ b/lua/d3bot/2_mapnavmeshui_cl.lua
@@ -55,7 +55,7 @@ return function(lib)
 			local id = table.remove(blockedNodeUpdateQueue, 1)
 			if not id then break end
 			local node = lib.MapNavMesh.NodeById[id]
-			blockedNodeById[id] = node and lib.IsNavMeshNodeBlocked(node.Params, node.Pos, wave) or false
+			blockedNodeById[id] = node and D3bot.IsNavMeshNodeBlocked(node.Params, node.Pos, wave) or false
 			table.insert(blockedNodeUpdateQueue, id)
 		end
 	end

--- a/lua/d3bot/2_mapnavmeshui_cl.lua
+++ b/lua/d3bot/2_mapnavmeshui_cl.lua
@@ -52,11 +52,10 @@ return function(lib)
 		end
 		local wave = getPathfindingWave()
 		for i = 1, batchSize do
-			local id = table.remove(blockedNodeUpdateQueue, 1)
+			local id = table.remove(blockedNodeUpdateQueue)
 			if not id then break end
 			local node = lib.MapNavMesh.NodeById[id]
 			blockedNodeById[id] = node and D3bot.IsNavMeshNodeBlocked(node.Params, node.Pos, wave) or false
-			table.insert(blockedNodeUpdateQueue, id)
 		end
 	end
 

--- a/lua/d3bot/azlib.lua
+++ b/lua/d3bot/azlib.lua
@@ -185,6 +185,7 @@ return function(globalK, otherLibFilesRelPathEach)
 	lib.Color.Orange = Color(255, 128, 0)
 	lib.Color.Yellow = Color(255, 255, 0)
 	lib.Color.Green = Color(0, 150, 0)
+	lib.Color.Blocked = Color(160, 0, 255)
 	for name, color in pairs(lib.Color) do
 		color.HalfAlpha = ColorAlpha(color, 128)
 		color.EightAlpha = ColorAlpha(color, 32)

--- a/lua/d3bot/sh_utilities.lua
+++ b/lua/d3bot/sh_utilities.lua
@@ -117,41 +117,44 @@ function D3bot.IsNavMeshNodeBlocked(nodeParams, nodePos, wave)
 	local nodeBlockingMap = D3bot.NodeBlockingMap
 	if not nodeBlocking or not nodeBlockingMap then return false end
 
-	local blocked = false
-
-	if nodeParams.Condition == "Unblocked" or nodeParams.Condition == "Blocked" then
+	if nodeParams.Condition == "Unblocked" then
 		local ents = ents.FindInBox(nodePos + nodeBlocking.mins, nodePos + nodeBlocking.maxs)
 		for _, ent in ipairs(ents) do
-			if nodeBlocking.classes[ent:GetClass()] then blocked = true; break end
+			if nodeBlocking.classes[ent:GetClass()] then return true end
 		end
-		if nodeParams.Condition == "Blocked" then blocked = not blocked end
+	elseif nodeParams.Condition == "Blocked" then
+		local ents = ents.FindInBox(nodePos + nodeBlocking.mins, nodePos + nodeBlocking.maxs)
+		local found = false
+		for _, ent in ipairs(ents) do
+			if nodeBlocking.classes[ent:GetClass()] then found = true; break end
+		end
+		if not found then return true end
 	elseif nodeParams.Condition == "MapUnblocked" then
 		local ents = ents.FindInBox(nodePos + nodeBlockingMap.mins, nodePos + nodeBlockingMap.maxs)
 		for _, ent in ipairs(ents) do
-			if nodeBlockingMap.classes[ent:GetClass()] then blocked = true; break end
+			if nodeBlockingMap.classes[ent:GetClass()] then return true end
 		end
 	end
 
-	if not blocked and nodeParams.BlockEntity then
+	if nodeParams.BlockEntity then
 		local blockRadius = tonumber(nodeParams.BlockRadius)
 		if blockRadius then
 			for _, ent in ipairs(ents.FindInSphere(nodePos, blockRadius)) do
 				if ent:GetClass() == nodeParams.BlockEntity then
-					blocked = true
-					break
+					return true
 				end
 			end
 		end
 	end
 
 	if nodeParams.BlockBeforeWave and tonumber(nodeParams.BlockBeforeWave) then
-		if wave < tonumber(nodeParams.BlockBeforeWave) then blocked = true end
+		if wave < tonumber(nodeParams.BlockBeforeWave) then return true end
 	end
 	if nodeParams.BlockAfterWave and tonumber(nodeParams.BlockAfterWave) then
-		if wave > tonumber(nodeParams.BlockAfterWave) then blocked = true end
+		if wave > tonumber(nodeParams.BlockAfterWave) then return true end
 	end
 
-	return blocked
+	return false
 end
 
 ---Calculates a falloff on the given nodes.

--- a/lua/d3bot/sh_utilities.lua
+++ b/lua/d3bot/sh_utilities.lua
@@ -91,6 +91,52 @@ function D3bot.RemoveObsDeadTgts(tgts)
 	return D3bot.From(tgts):Where(function(k, v) return IsValid(v) and v:GetObserverMode() == OBS_MODE_NONE and not v:IsFlagSet(FL_NOTARGET) and v:Alive() end).R
 end
 
+---@param nodeParams table
+---@param nodePos Vector
+---@param wave number
+---@return boolean
+function D3bot.IsNavMeshNodeBlocked(nodeParams, nodePos, wave)
+	local nodeBlocking = D3bot.NodeBlocking
+	local nodeBlockingMap = D3bot.NodeBlockingMap
+	if not nodeBlocking or not nodeBlockingMap then return false end
+
+	local blocked = false
+
+	if nodeParams.Condition == "Unblocked" or nodeParams.Condition == "Blocked" then
+		local ents = ents.FindInBox(nodePos + nodeBlocking.mins, nodePos + nodeBlocking.maxs)
+		for _, ent in ipairs(ents) do
+			if nodeBlocking.classes[ent:GetClass()] then blocked = true; break end
+		end
+		if nodeParams.Condition == "Blocked" then blocked = not blocked end
+	elseif nodeParams.Condition == "MapUnblocked" then
+		local ents = ents.FindInBox(nodePos + nodeBlockingMap.mins, nodePos + nodeBlockingMap.maxs)
+		for _, ent in ipairs(ents) do
+			if nodeBlockingMap.classes[ent:GetClass()] then blocked = true; break end
+		end
+	end
+
+	if not blocked and nodeParams.BlockEntity then
+		local blockRadius = tonumber(nodeParams.BlockRadius)
+		if blockRadius then
+			for _, ent in ipairs(ents.FindInSphere(nodePos, blockRadius)) do
+				if ent:GetClass() == nodeParams.BlockEntity then
+					blocked = true
+					break
+				end
+			end
+		end
+	end
+
+	if nodeParams.BlockBeforeWave and tonumber(nodeParams.BlockBeforeWave) then
+		if wave < tonumber(nodeParams.BlockBeforeWave) then blocked = true end
+	end
+	if nodeParams.BlockAfterWave and tonumber(nodeParams.BlockAfterWave) then
+		if wave > tonumber(nodeParams.BlockAfterWave) then blocked = true end
+	end
+
+	return blocked
+end
+
 ---Calculates a falloff on the given nodes.
 ---@param startNode D3NavmeshNode|nil -- The node to start on.
 ---@param iterations integer -- The maximum number of iterations.

--- a/lua/d3bot/sh_utilities.lua
+++ b/lua/d3bot/sh_utilities.lua
@@ -109,7 +109,7 @@ D3bot.NodeBlockingMap = {
 }
 
 ---@param nodeParams table
----@param nodePos Vector
+---@param nodePos GVector
 ---@param wave number
 ---@return boolean
 function D3bot.IsNavMeshNodeBlocked(nodeParams, nodePos, wave)

--- a/lua/d3bot/sh_utilities.lua
+++ b/lua/d3bot/sh_utilities.lua
@@ -91,6 +91,23 @@ function D3bot.RemoveObsDeadTgts(tgts)
 	return D3bot.From(tgts):Where(function(k, v) return IsValid(v) and v:GetObserverMode() == OBS_MODE_NONE and not v:IsFlagSet(FL_NOTARGET) and v:Alive() end).R
 end
 
+-- List of entities that will be used to check whether nodes are blocked or unblocked.
+-- Used by the condition=blocked and condition=unblocked parameters.
+D3bot.NodeBlocking = {
+	mins = Vector(-1, -1, -1),
+	maxs = Vector(1, 1, 1),
+	classes = {func_breakable = true, prop_physics = true, prop_dynamic = true, prop_door_rotating = true, func_door = true, func_physbox = true, func_physbox_multiplayer = true, func_movelinear = true}
+}
+
+-- List of entities that will be used to check whether nodes are blocked or unblocked.
+-- Used by the condition=MapUnblocked parameter.
+-- This specific variant excludes anything that can be used to cade.
+D3bot.NodeBlockingMap = {
+	mins = Vector(-1, -1, -1),
+	maxs = Vector(1, 1, 1),
+	classes = {func_breakable = true, prop_dynamic = true, prop_door_rotating = true, func_door = true, func_movelinear = true}
+}
+
 ---@param nodeParams table
 ---@param nodePos Vector
 ---@param wave number

--- a/lua/d3bot/sv_config.lua
+++ b/lua/d3bot/sv_config.lua
@@ -3,17 +3,6 @@ D3bot.BotSeeTr = {
 	maxs = Vector(15, 15, 15),
 	mask = MASK_PLAYERSOLID
 }
-D3bot.NodeBlocking = {
-	mins = Vector(-1, -1, -1),
-	maxs = Vector(1, 1, 1),
-	classes = {func_breakable = true, prop_physics = true, prop_dynamic = true, prop_door_rotating = true, func_door = true, func_physbox = true, func_physbox_multiplayer = true, func_movelinear = true}
-}
-
-D3bot.NodeBlockingMap = {
-	mins = Vector(-1, -1, -1),
-	maxs = Vector(1, 1, 1),
-	classes = {func_breakable = true, prop_dynamic = true, prop_door_rotating = true, func_door = true, func_movelinear = true}
-}
 
 D3bot.ValveNav = true						-- Enable the use of auto-generated nav-meshes ("SourceNav"). You can create these by using the console command "nav_generate".
 D3bot.ValveNavOverride = false				-- When true: Prefer auto-generated nav-meshes ("SourceNav") over manually created nav-meshes ("D3botNav").

--- a/lua/d3bot/sv_path.lua
+++ b/lua/d3bot/sv_path.lua
@@ -59,28 +59,7 @@ function D3bot.GetBestMeshPathOrNil(startNode, endNode, pathCostFunction, heuris
 				link.CachedZDiff = linkZDiff -- The cache will be invalidated on any navmesh change.
 			end
 
-			local blocked = false
-			if linkedNodeParams.Condition == "Unblocked" or linkedNodeParams.Condition == "Blocked" then
-				local ents = ents.FindInBox(linkedNode.Pos + D3bot.NodeBlocking.mins, linkedNode.Pos + D3bot.NodeBlocking.maxs)
-				for _, ent in ipairs(ents) do
-					if D3bot.NodeBlocking.classes[ent:GetClass()] then blocked = true; break end
-				end
-				if linkedNodeParams.Condition == "Blocked" then blocked = not blocked end
-			elseif linkedNodeParams.Condition == "MapUnblocked" then
-				local ents = ents.FindInBox(linkedNode.Pos + D3bot.NodeBlockingMap.mins, linkedNode.Pos + D3bot.NodeBlockingMap.maxs)
-				for _, ent in ipairs(ents) do
-					if D3bot.NodeBlockingMap.classes[ent:GetClass()] then blocked = true; break end
-				end
-			end
-
-			-- Block pathing if the wave is outside of the interval [BlockBeforeWave, BlockAfterWave].
-			if linkedNodeParams.BlockBeforeWave and tonumber(linkedNodeParams.BlockBeforeWave) then
-				if wave < tonumber(linkedNodeParams.BlockBeforeWave) then blocked = true end
-			end
-			if linkedNodeParams.BlockAfterWave and tonumber(linkedNodeParams.BlockAfterWave) then
-				if wave > tonumber(linkedNodeParams.BlockAfterWave) then blocked = true end
-				-- TODO: Invert logic when BlockBeforeWave > BlockAfterWave. This way it's possible to describe a interval of blocked waves, instead of unblocked waves
-			end
+			local blocked = D3bot.IsNavMeshNodeBlocked(linkedNodeParams, linkedNode.Pos, wave)
 
 			-- Check how we traverse the current link. It's forwards if we go from link.Nodes[1] to link.Nodes[2].
 			local forwards = link.Nodes[1] == node
@@ -212,25 +191,9 @@ function D3bot.GetEscapeMeshPathOrNil(startNode, iterations, pathCostFunction, h
 		end
 		
 		for linkedNode, link in pairs(node.LinkByLinkedNode) do
-			
-			local blocked = false
-			if linkedNode.Params.Condition == "Unblocked" or linkedNode.Params.Condition == "Blocked" then
-				local ents = ents.FindInBox(linkedNode.Pos + D3bot.NodeBlocking.mins, linkedNode.Pos + D3bot.NodeBlocking.maxs)
-				for _, ent in ipairs(ents) do
-					if D3bot.NodeBlocking.classes[ent:GetClass()] then blocked = true; break end
-				end
-				if linkedNode.Params.Condition == "Blocked" then blocked = not blocked end
-			end
 
-			-- Block pathing if the wave is outside of the interval [BlockBeforeWave, BlockAfterWave]
-			if linkedNode.Params.BlockBeforeWave and tonumber(linkedNode.Params.BlockBeforeWave) then
-				if GAMEMODE:GetWave() < tonumber(linkedNode.Params.BlockBeforeWave) then blocked = true end
-			end
-			if linkedNode.Params.BlockAfterWave and tonumber(linkedNode.Params.BlockAfterWave) then
-				if GAMEMODE:GetWave() > tonumber(linkedNode.Params.BlockAfterWave) then blocked = true end
-				-- TODO: Invert logic when BlockBeforeWave > BlockAfterWave. This way it's possible to describe a interval of blocked waves, instead of unblocked waves
-			end
-			
+			local blocked = D3bot.IsNavMeshNodeBlocked(linkedNode.Params, linkedNode.Pos, GAMEMODE:GetWave())
+
 			local able = true
 			if link.Params.Walking == "Needed" and abilities and not abilities.Walk then able = false end
 			if link.Params.Pouncing == "Needed" and abilities and not abilities.Pounce then able = false end


### PR DESCRIPTION
This adds the `BlockEntity` and `BlockRadius` parameters to nodes. A node within its `BlockRadius` of its `BlockEntity` classname becomes disabled, forcing bots to find a new path.

This system also has a far wider potential for use than the incumbent `Condition` system.

There is also an overlay of the feature when previewing the mesh (it doesn't have to be this large):

<img width="1092" height="794" alt="gmod_2TVD3WgAOz" src="https://github.com/user-attachments/assets/d2813933-f1bd-41dc-bd7b-fd7a85074c5a" />
